### PR TITLE
scopes to scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,12 @@ const redirectWithQueryString = (res, data) => {
 const login = async (req, res) => {
   const state = await uid(20);
   states.push(state);
-  const { scopes, allow_signup } = req.query;
+  const { scope, allow_signup } = req.query;
   const query = {
     client_id: process.env.GH_CLIENT_ID,
     state: state
   };
-  if (scopes) query.scopes = scopes;
+  if (scope) query.scope = scope;
   if (allow_signup !== undefined) query.allow_signup = allow_signup;
   redirect(res, 302, `https://${githubUrl}/login/oauth/authorize?${querystring.stringify(query)}`);
 };


### PR DESCRIPTION
Hi, first, thanks for this very convenient library.
I'm reasonably sure that the current set up doesn't allow for scopes to be sent along.

The readme for this project says `You can change the scope of the data you can access with the scope query param, see the GitHub docs!` [The Github docs confirm that they expect a `scope` param.](https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#parameters)

But the code is adding a query param `scopes` (plural) to the oauth request to Github.

When I made the following change and redeployed, I was able to add scopes successfully, but not before that. 

It would be great if someone could double check this just in case I misattributed my initial failure to the `scopes` vs `scope` issue, but there was actually something else going on.

