### PR TITLE
Refactor for Zeit 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2019-08-07
+### Added
+- Refactor to support Zeit Now's 2.0 routing system.
+
 ## [1.0.0] - 2017-04-01
 ### Added
 - Support for state parameter to protect against cross-site request forgery attacks. Requires users to use the provided `/login` url and moves redirect url from `/` to `/callback`

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ When authentication was successful, the user will be redirected to the `REDIRECT
 
 ### Finish setup
 
-To make this work you have to set the authorization callback URL of [your application on GitHub](https://github.com/settings/developers) to whatever URL `now` gave you plus the path `/callback` e.g. `http://localhost:3000/callback`:
+To make this work you have to set the authorization callback URL of [your application on GitHub](https://github.com/settings/developers) to whatever URL `now` gave you plus the path `/api/callback` e.g. `http://localhost:3000/api/callback`:
 
-![Authorization callback URL: 'your-url.now.sh'](https://cloud.githubusercontent.com/assets/168870/24585953/9543e03a-178e-11e7-8f10-07be5c10682c.png)
+![Authorization callback URL: 'your-url.now.sh'](https://user-images.githubusercontent.com/174475/62680084-3e566780-b96b-11e9-9fb8-986da2356abe.png)
 
-To log people in provide a link to url `now` gave you plus the path `login` e.g. `http://localhost:3000/login` when they click on the link it will redirect to `https://github.com/login/oauth/authorize?client_id=asdf123&state`. (where `client_id` is your GitHub app client id in `.env` and `state` is a randomly generated string). This will redirect them to the GitHub sign in page for your app, which looks like this:
+To log people in provide a link to url `now` gave you plus the path `login` e.g. `http://localhost:3000/api/login` when they click on the link it will redirect to `https://github.com/login/oauth/authorize?client_id=asdf123&state`. (where `client_id` is your GitHub app client id in `.env` and `state` is a randomly generated string). This will redirect them to the GitHub sign in page for your app, which looks like this:
 
 ![Authorize my app to access your data on GitHub](https://cloud.githubusercontent.com/assets/7525670/22627265/fc50c680-ebbf-11e6-9126-dcdef37d3c3d.png)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To make this work you have to set the authorization callback URL of [your applic
 
 ![Authorization callback URL: 'your-url.now.sh'](https://user-images.githubusercontent.com/174475/62680084-3e566780-b96b-11e9-9fb8-986da2356abe.png)
 
-To log people in provide a link to url `now` gave you plus the path `login` e.g. `http://localhost:3000/api/login` when they click on the link it will redirect to `https://github.com/login/oauth/authorize?client_id=asdf123&state`. (where `client_id` is your GitHub app client id in `.env` and `state` is a randomly generated string). This will redirect them to the GitHub sign in page for your app, which looks like this:
+To log people in provide a link to url `now` gave you plus the path `/api/login` e.g. `http://localhost:3000/api/login` when they click on the link it will redirect to `https://github.com/login/oauth/authorize?client_id=asdf123&state`. (where `client_id` is your GitHub app client id in `.env` and `state` is a randomly generated string). This will redirect them to the GitHub sign in page for your app, which looks like this:
 
 ![Authorize my app to access your data on GitHub](https://cloud.githubusercontent.com/assets/7525670/22627265/fc50c680-ebbf-11e6-9126-dcdef37d3c3d.png)
 

--- a/api/[action].js
+++ b/api/[action].js
@@ -9,7 +9,7 @@ const githubUrl = process.env.GH_HOST || 'github.com'
 const states = [];
 
 const redirectWithQueryString = (res, data) => {
-  const location = `${process.env.REDIRECT_URL}#${querystring.stringify(data)}`
+  const location = `${process.env.REDIRECT_URL}?${querystring.stringify(data)}`
   redirect(res, 302, location)
 }
 
@@ -21,7 +21,7 @@ const login = async (req, res) => {
     client_id: process.env.GH_CLIENT_ID,
     state: state
   };
-  query.scope = 'read:user,repo,user:email';
+  if (scope) query.scope = scope;
   if (allow_signup !== undefined) query.allow_signup = allow_signup;
   redirect(res, 302, `https://${githubUrl}/login/oauth/authorize?${querystring.stringify(query)}`);
 };

--- a/api/[action].js
+++ b/api/[action].js
@@ -1,7 +1,6 @@
 require('dotenv').config()
-const querystring = require('querystring')
-const axios = require('axios')
-const { router, get } = require('microrouter');
+const querystring = require('querystring');
+const axios = require('axios');
 const redirect = require('micro-redirect');
 const uid = require('uid-promise');
 
@@ -10,7 +9,7 @@ const githubUrl = process.env.GH_HOST || 'github.com'
 const states = [];
 
 const redirectWithQueryString = (res, data) => {
-  const location = `${process.env.REDIRECT_URL}?${querystring.stringify(data)}`
+  const location = `${process.env.REDIRECT_URL}#${querystring.stringify(data)}`
   redirect(res, 302, location)
 }
 
@@ -22,7 +21,7 @@ const login = async (req, res) => {
     client_id: process.env.GH_CLIENT_ID,
     state: state
   };
-  if (scope) query.scope = scope;
+  query.scope = 'read:user,repo,user:email';
   if (allow_signup !== undefined) query.allow_signup = allow_signup;
   redirect(res, 302, `https://${githubUrl}/login/oauth/authorize?${querystring.stringify(query)}`);
 };
@@ -66,7 +65,13 @@ const callback = async (req, res) => {
   }
 }
 
-module.exports = router(
-  get('/login', login),
-  get('/callback', callback)
-);
+// api/[action].js
+// https://micro-github.*USERNAME*.now.sh/api/login
+// https://micro-github.*USERNAME*.now.sh/api/callback
+module.exports = (req, res) => {
+  if(req.query.action === "login"){
+    login(req, res);
+  }else if(req.query.action === "callback"){
+    callback(req, res);
+  }
+}

--- a/now.json
+++ b/now.json
@@ -1,0 +1,11 @@
+{
+  "name":"micro-github",
+  "version": 2,
+  "build": {
+    "env": {
+      "GH_CLIENT_ID": "@gh-client-id",
+      "GH_CLIENT_SECRET": "@gh-client-secret",
+      "REDIRECT_URL": "@redirect-url"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micro-github",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,6 @@
     "dotenv": "^4.0.0",
     "micro": "^6.2.1",
     "micro-redirect": "^1.0.0",
-    "microrouter": "^2.0.1",
     "uid-promise": "^0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace `microrouter` with Zeit 2.0's new `api` routing system.

This new system is currently being used for https://gitographer.com/